### PR TITLE
fix: remove extra '%' from LTI_DEFAULT_JUPYTER_HUB_URL

### DIFF
--- a/changelog.d/20241212_183857_danyal.faheem_fix_base_url.md
+++ b/changelog.d/20241212_183857_danyal.faheem_fix_base_url.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix the LTI_DEFAULT_JUPYTER_HUB_URL which had an extra '%' in the HTTPS URL. (by @Danyal-Faheem)

--- a/tutorjupyter/patches/openedx-common-settings
+++ b/tutorjupyter/patches/openedx-common-settings
@@ -1,3 +1,3 @@
 # Jupyter XBlock
 LTI_DEFAULT_JUPYTER_PASSPORT_ID = "{{ JUPYTER_DEFAULT_PASSPORT_ID }}"
-LTI_DEFAULT_JUPYTER_HUB_URL = "{% if ENABLE_HTTPS %}%https{% else %}http{% endif %}://{{ JUPYTER_HOST }}"
+LTI_DEFAULT_JUPYTER_HUB_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ JUPYTER_HOST }}"

--- a/tutorjupyter/patches/openedx-development-settings
+++ b/tutorjupyter/patches/openedx-development-settings
@@ -1,3 +1,3 @@
 LTI_DEFAULT_JUPYTER_PASSPORT_ID = "{{ JUPYTER_DEFAULT_PASSPORT_ID }}"
-LTI_DEFAULT_JUPYTER_HUB_URL = "{% if ENABLE_HTTPS %}%https{% else %}http{% endif %}://{{ JUPYTER_HOST }}:9045"
+LTI_DEFAULT_JUPYTER_HUB_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ JUPYTER_HOST }}:9045"
 


### PR DESCRIPTION
Fixes the issue where Jupyter Xblock does not load when used with ENABLE_HTTPS=True.