### PR TITLE
Revert "fix: remove preview sites from allowed embedding pages (#25)"

### DIFF
--- a/tutorjupyter/templates/jupyter/apps/jupyterhub_config.py
+++ b/tutorjupyter/templates/jupyter/apps/jupyterhub_config.py
@@ -29,6 +29,8 @@ frame_ancestors = [
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}:8000",
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}",
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}:8001",
+    "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ PREVIEW_LMS_HOST }}",
+    "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ PREVIEW_LMS_HOST }}:8000",
 ]
 {% if MFE_HOST is defined %}
 frame_ancestors += [


### PR DESCRIPTION
This reverts commit 54507f41fe92e5d2ba60a89e031521c1fd8c8f3a.

We revert this commit as the upstream change was merged in the master branch and is not to be backported to teak. Therefore, the current builds running on top of teak are failing.