### PR TITLE
fix: remove preview sites from allowed embedding pages

### DIFF
--- a/changelog.d/20250521_190353_danyal.faheem_remove_preview.md
+++ b/changelog.d/20250521_190353_danyal.faheem_remove_preview.md
@@ -1,0 +1,1 @@
+- [Improvement] Remove preview sites from allowed embedding pages as the preview page has been migrated to the learning MFE. (by @Danyal-Faheem)

--- a/changelog.d/20250521_190353_danyal.faheem_remove_preview.md
+++ b/changelog.d/20250521_190353_danyal.faheem_remove_preview.md
@@ -1,1 +1,1 @@
-- [Improvement] Remove preview sites from allowed embedding pages as the preview page has been migrated to the learning MFE. (by @Danyal-Faheem)
+- 💥[Improvement] Remove preview sites from allowed embedding pages as the preview page has been migrated to the learning MFE. (by @Danyal-Faheem)

--- a/tutorjupyter/templates/jupyter/apps/jupyterhub_config.py
+++ b/tutorjupyter/templates/jupyter/apps/jupyterhub_config.py
@@ -29,8 +29,6 @@ frame_ancestors = [
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}:8000",
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}",
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}:8001",
-    "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ PREVIEW_LMS_HOST }}",
-    "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ PREVIEW_LMS_HOST }}:8000",
 ]
 {% if MFE_HOST is defined %}
 frame_ancestors += [


### PR DESCRIPTION
Original issue: https://github.com/overhangio/tutor/issues/1231
This PR is dependent on https://github.com/overhangio/tutor/pull/1238 to be merged first

This is because the preview pages have been migrated to the learning MFE and now do not run on a separate domain.

This PR was initially added in #25 and later reverted in #26 as the change was never meant to be added to the teak release but it had been rebased into the teak branch in tutor-jupyter. We now add it to the main branch to stay up to date with the master branch.